### PR TITLE
Implement 1-to-1 Relationship Between Auction and Product Entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4189,7 +4189,6 @@
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/auction/entities/auction.entity.ts
+++ b/src/auction/entities/auction.entity.ts
@@ -4,13 +4,12 @@ import {
   Column,
   DataType,
   ForeignKey,
-  HasMany,
   Model,
   Table,
 } from 'sequelize-typescript';
+import { Product } from 'src/products/entities/product.entity';
 import { UserAuction } from 'src/user-auction/entities/user-auction.entity';
 import { User } from 'src/users/entities/users.entity';
-import { Product } from 'src/products/entities/product.entity';
 
 export enum AuctionType {
   TraditionalAuctions = 'traditional auctions',
@@ -48,17 +47,19 @@ export class Auction extends Model {
   endDate: Date;
 
   @Column({
-    type: DataType.CHAR,
-    allowNull: false,
-  })
-  productId: string;
-
-  @Column({
     type: DataType.ENUM,
     values: Object.values(AuctionType),
     allowNull: false,
   })
   auctionType: string;
+
+  @ForeignKey(() => Product)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+    unique: true,
+  })
+  productId: string;
 
   @ForeignKey(() => User)
   @Column({
@@ -67,13 +68,17 @@ export class Auction extends Model {
   })
   userId: string;
 
-  //TODO: relations
-  //   @HasMany(() => Product)
-  //   products: Product[];
+  // Relations
 
+  // 1 -> 1: One auction has one product
+  @BelongsTo(() => Product)
+  product: Product;
+
+  // N -> 1: Many auctions are created by one user
   @BelongsTo(() => User)
   user: User;
 
+  // N -> N: Many auctions can have many users (bidders)
   @BelongsToMany(() => User, () => UserAuction)
   users: User[];
 }

--- a/src/products/entities/product.entity.ts
+++ b/src/products/entities/product.entity.ts
@@ -3,11 +3,13 @@ import {
   Column,
   DataType,
   ForeignKey,
+  HasOne,
   Model,
   Table,
 } from 'sequelize-typescript';
 import { Category } from './category.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { Auction } from 'src/auction/entities/auction.entity';
 
 @Table({
   tableName: 'Products',
@@ -15,10 +17,9 @@ import { ApiProperty } from '@nestjs/swagger';
 export class Product extends Model {
   @ApiProperty()
   @Column({
-    type: DataType.STRING,
-    allowNull: false,
+    type: DataType.UUID,
+    defaultValue: DataType.UUIDV4,
     primaryKey: true,
-    unique: true,
   })
   id: string;
 
@@ -57,6 +58,12 @@ export class Product extends Model {
   })
   categoryId: string;
 
+  // Relations
+  // 1 -> 1: A product has one auction
+  @HasOne(() => Auction)
+  auction: Auction;
+
+  // N -> 1: Many products belong to one category
   @BelongsTo(() => Category)
   categoryEntity: Category;
 }


### PR DESCRIPTION
### Implemente Relación Uno a Uno Entre Entidades de Subasta y Producto

Este PR implementa una relación uno a uno entre las entidades `Auction` y `Product`. Los cambios incluyen:

- Actualización de la entidad `Product` para incluir una relación `HasOne` con la entidad `Auction`.
- Actualización de la entidad `Auction` para incluir una relación `BelongsTo` con la entidad `Product`.
- Ajuste del esquema de la base de datos para asegurar que las restricciones de clave foránea se implementen correctamente.